### PR TITLE
Bug fixes + Makefile refactor and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(PDF_DIR)/%.pdf: $(HTML_DIR)/%.html
 # Use $(RESUME_TEMPLATE) as a template (see pandoc templates)
 $(HTML_DIR)/$(RESUMES_SUBDIR)/%.html: $(MD_DIR)/$(RESUMES_SUBDIR)/%.$(MD_EXT)
 	mkdir -p $(@D)
-	pandoc --template $(RESUMES_TEMPLATE) $< --from markdown --to html -o $@
+	pandoc --template $(RESUME_TEMPLATE) $< --from markdown --to html -o $@
 
 # Do the same for references
 $(HTML_DIR)/$(REFERENCES_SUBDIR)/%.html: $(MD_DIR)/$(REFERENCES_SUBDIR)/%.$(MD_EXT)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-# Directories which contains markdown content for resumes
-# and reference pages
-RESUMES_MD_DIR = md/resumes
-REFERENCES_MD_DIR = md/references
+# Markdown source and html, pdf destination directories
+MD_DIR = md
+HTML_DIR = html
+PDF_DIR = pdf
+
+# Subdirectories for resumes and references (inside the above dirs)
+RESUMES_SUBDIR = resumes
+REFERENCES_SUBDIR = references
 
 # File extension for markdown to be converted to html, then pdf
 MD_EXT = md
@@ -10,63 +14,46 @@ MD_EXT = md
 RESUME_TEMPLATE = templates/resume-template.html
 REFERENCES_TEMPLATE = templates/references-template.html
 
-# Destination directores for generated html resumes
-# and reference pages
-RESUMES_HTML_DIR = html/resumes
-REFERENCES_HTML_DIR = html/references
-# Destination directory for generated pdf resumes
-# and reference pages
-RESUMES_PDF_DIR = pdf/resumes
-REFERENCES_PDF_DIR = pdf/references
-
-# Construct list of markdown sources
-RESUMES_MD_SOURCES := $(wildcard $(RESUMES_MD_DIR)/*.$(MD_EXT))
-REFERENCES_MD_SOURCES := $(wildcard $(REFERENCES_MD_DIR)/*.$(MD_EXT))
-
-# Construct list of resume and reference page html intermediates
-RESUMES_HTML_TARGETS = $(patsubst $(RESUMES_MD_DIR)/%, $(RESUMES_HTML_DIR)/%, $(RESUMES_MD_SOURCES:.$(MD_EXT)=.html))
-REFERENCES_HTML_TARGETS = $(patsubst $(REFERENCES_MD_DIR)/%, $(REFERENCES_HTML_DIR)/%, $(REFERENCES_MD_SOURCES:.$(MD_EXT)=.html))
-
-# Construct list of resume and reference page pdfs which should have been built
-RESUMES_PDF_TARGETS = $(patsubst $(RESUMES_MD_DIR)/%, $(RESUMES_PDF_DIR)/%, $(RESUMES_MD_SOURCES:.$(MD_EXT)=.pdf))
-REFERENCES_PDF_TARGETS = $(patsubst $(REFERENCES_MD_DIR)/%, $(REFERENCES_PDF_DIR)/%, $(REFERENCES_MD_SOURCES:.$(MD_EXT)=.pdf))
-
 # Formatting for the html to pdf conversion
 PAGE_SIZE = Letter
 MARGIN_TOP_BOTTOM = 0.9in
 MARGIN_LEFT_RIGHT = 0.9in
 
-all: $(RESUMES_PDF_TARGETS) $(REFERENCES_PDF_TARGETS)
 
-html: $(RESUMES_HTML_TARGETS) $(REFERENCES_HTML_TARGETS)
+# Construct list of markdown sources
+MD_SOURCES := $(wildcard $(MD_DIR)/*/*.$(MD_EXT))
 
-# Create pdf directory if it doesn't exist
+# Construct list of html intermediates
+HTML_TARGETS = $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(HTML_DIR)/%.html)
+
+# Construct list of final pdfs
+PDF_TARGETS = $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(PDF_DIR)/%.pdf)
+
+all: $(PDF_TARGETS)
+
+html: $(HTML_TARGETS)
+
 # Convert html to pdf
-$(RESUMES_PDF_DIR)/%.pdf: $(RESUMES_HTML_DIR)/%.html
-	mkdir -p $(RESUMES_PDF_DIR)
-	wkhtmltopdf --page-size $(PAGE_SIZE) --margin-top $(MARGIN_TOP_BOTTOM) --margin-bottom $(MARGIN_TOP_BOTTOM) --margin-left $(MARGIN_LEFT_RIGHT) --margin-right $(MARGIN_LEFT_RIGHT) $< $@
-
-# Do the same for references
-$(REFERENCES_PDF_DIR)/%.pdf: $(REFERENCES_HTML_DIR)/%.html
-	mkdir -p $(REFERENCES_PDF_DIR)
-	wkhtmltopdf --page-size $(PAGE_SIZE) --margin-top $(MARGIN_TOP_BOTTOM) --margin-bottom $(MARGIN_TOP_BOTTOM) --margin-left $(MARGIN_LEFT_RIGHT) --margin-right $(MARGIN_LEFT_RIGHT) $< $@
+$(PDF_DIR)/%.pdf: $(HTML_DIR)/%.html
+	mkdir -p $(@D)
+	wkhtmltopdf --page-size $(PAGE_SIZE) \
+		--margin-top $(MARGIN_TOP_BOTTOM) --margin-bottom $(MARGIN_TOP_BOTTOM) \
+		--margin-left $(MARGIN_LEFT_RIGHT) --margin-right $(MARGIN_LEFT_RIGHT) \
+		$< $@
 
 # Use pandoc to convert markdown content to html
 # Use $(RESUME_TEMPLATE) as a template (see pandoc templates)
-# Save the result as $(RESUME_HTML)
-$(RESUMES_HTML_DIR)/%.html: $(RESUMES_MD_DIR)/%.$(MD_EXT)
-	mkdir -p $(RESUMES_HTML_DIR)
-	pandoc --template $(RESUME_TEMPLATE) $< --from markdown --to html -o $@
+$(HTML_DIR)/$(RESUMES_SUBDIR)/%.html: $(MD_DIR)/$(RESUMES_SUBDIR)/%.$(MD_EXT)
+	mkdir -p $(@D)
+	pandoc --template $(RESUMES_TEMPLATE) $< --from markdown --to html -o $@
 
 # Do the same for references
-$(REFERENCES_HTML_DIR)/%.html: $(REFERENCES_MD_DIR)/%.$(MD_EXT)
-	mkdir -p $(REFERENCES_HTML_DIR)
+$(HTML_DIR)/$(REFERENCES_SUBDIR)/%.html: $(MD_DIR)/$(REFERENCES_SUBDIR)/%.$(MD_EXT)
+	mkdir -p $(@D)
 	pandoc --template $(REFERENCES_TEMPLATE) $< --from markdown --to html -o $@
 
 
 .PHONY: clean
 clean:
-	-rm -r $(RESUMES_HTML_DIR)
-	-rm -r $(RESUMES_PDF_DIR)
-	-rm -r $(REFERENCES_HTML_DIR)
-	-rm -r $(REFERENCES_PDF_DIR)
+	-rm -rf $(HTML_DIR)/*
+	-rm -rf $(PDF_DIR)/*

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ html: $(HTML_TARGETS)
 # Convert html to pdf
 $(PDF_DIR)/%.pdf: $(HTML_DIR)/%.html
 	mkdir -p $(@D)
-	wkhtmltopdf --page-size $(PAGE_SIZE) \
+	wkhtmltopdf --enable-local-file-access --page-size $(PAGE_SIZE) \
 		--margin-top $(MARGIN_TOP_BOTTOM) --margin-bottom $(MARGIN_TOP_BOTTOM) \
 		--margin-left $(MARGIN_LEFT_RIGHT) --margin-right $(MARGIN_LEFT_RIGHT) \
 		$< $@

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ MARGIN_LEFT_RIGHT = 0.9in
 MD_SOURCES := $(wildcard $(MD_DIR)/*/*.$(MD_EXT))
 
 # Construct list of html intermediates
-HTML_TARGETS = $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(HTML_DIR)/%.html)
+HTML_TARGETS := $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(HTML_DIR)/%.html)
 
 # Construct list of final pdfs
-PDF_TARGETS = $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(PDF_DIR)/%.pdf)
+PDF_TARGETS := $(MD_SOURCES:$(MD_DIR)/%.$(MD_EXT)=$(PDF_DIR)/%.pdf)
 
 all: $(PDF_TARGETS)
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ $(REFERENCES_HTML_DIR)/%.html: $(REFERENCES_MD_DIR)/%.$(MD_EXT)
 	mkdir -p $(REFERENCES_HTML_DIR)
 	pandoc --template $(REFERENCES_TEMPLATE) $< --from markdown --to html -o $@
 
+
+.PHONY: clean
 clean:
 	-rm -r $(RESUMES_HTML_DIR)
 	-rm -r $(RESUMES_PDF_DIR)

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ REFERENCES_TEMPLATE = templates/references-template.html
 # Destination directores for generated html resumes
 # and reference pages
 RESUMES_HTML_DIR = html/resumes
-REFERENCES_HTML_DIR = html/resumes
+REFERENCES_HTML_DIR = html/references
 # Destination directory for generated pdf resumes
 # and reference pages
 RESUMES_PDF_DIR = pdf/resumes
 REFERENCES_PDF_DIR = pdf/references
 
 # Construct list of markdown sources
-RESUMES_MD_SOURCES = $(shell find $(RESUMES_MD_DIR) -type f -name "*.$(MD_EXT)")
-REFERENCES_MD_SOURCES = $(shell find $(REFERENCES_MD_DIR) -type f -name "*.$(MD_EXT)")
+RESUMES_MD_SOURCES := $(wildcard $(RESUMES_MD_DIR)/*.$(MD_EXT))
+REFERENCES_MD_SOURCES := $(wildcard $(REFERENCES_MD_DIR)/*.$(MD_EXT))
 
 # Construct list of resume and reference page html intermediates
 RESUMES_HTML_TARGETS = $(patsubst $(RESUMES_MD_DIR)/%, $(RESUMES_HTML_DIR)/%, $(RESUMES_MD_SOURCES:.$(MD_EXT)=.html))

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ MD_EXT = md
 RESUME_TEMPLATE = templates/resume-template.html
 REFERENCES_TEMPLATE = templates/references-template.html
 
+RESUME_TEMPLATE_DEPS = css/base.css img/dummy.png
+REFERENCES_TEMPLATE_DEPS = $(RESUME_TEMPLATE_DEPS) css/references.css
+
 # Formatting for the html to pdf conversion
 PAGE_SIZE = Letter
 MARGIN_TOP_BOTTOM = 0.9in
@@ -43,12 +46,14 @@ $(PDF_DIR)/%.pdf: $(HTML_DIR)/%.html
 
 # Use pandoc to convert markdown content to html
 # Use $(RESUME_TEMPLATE) as a template (see pandoc templates)
-$(HTML_DIR)/$(RESUMES_SUBDIR)/%.html: $(MD_DIR)/$(RESUMES_SUBDIR)/%.$(MD_EXT)
+$(HTML_DIR)/$(RESUMES_SUBDIR)/%.html: $(MD_DIR)/$(RESUMES_SUBDIR)/%.$(MD_EXT) \
+		$(RESUME_TEMPLATE) $(RESUME_TEMPLATE_DEPS)
 	mkdir -p $(@D)
 	pandoc --template $(RESUME_TEMPLATE) $< --from markdown --to html -o $@
 
 # Do the same for references
-$(HTML_DIR)/$(REFERENCES_SUBDIR)/%.html: $(MD_DIR)/$(REFERENCES_SUBDIR)/%.$(MD_EXT)
+$(HTML_DIR)/$(REFERENCES_SUBDIR)/%.html: $(MD_DIR)/$(REFERENCES_SUBDIR)/%.$(MD_EXT) \
+		$(REFERENCES_TEMPLATE) $(REFERENCES_TEMPLATE_DEPS)
 	mkdir -p $(@D)
 	pandoc --template $(REFERENCES_TEMPLATE) $< --from markdown --to html -o $@
 

--- a/md/references/references.md
+++ b/md/references/references.md
@@ -1,4 +1,5 @@
 ---
+title: 'References' # HTML title, ignored in final PDF
 name: 'John Doe'
 logo: '../../img/dummy.png'
 street: '123 Road St'

--- a/md/resumes/resume.md
+++ b/md/resumes/resume.md
@@ -1,4 +1,5 @@
 ---
+title: 'Resume' # HTML title, ignored in final PDF
 name: 'John Doe'
 logo: '../../img/dummy.png'
 street: '123 Road St'


### PR DESCRIPTION
- Cleans up Makefile significantly by only treating resumes and references separately when considering the pandoc markdown-to- html conversion (different templates)
- Adds some code quality changes (simply expanded variables, phony)
- Updates recipes for wkhtmltopdf 0.12.6+
- Adds titles to markdown YAML metadata to stop pandoc from complaining (and is nice for browser tabs when editing html) 